### PR TITLE
docs: spellcheck - correct typos + use US English

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -23,16 +23,16 @@ lib-cove-ocds
 
 lib-cove-ocds contains OCDS data specific functions, but in a way that means they can be reused by other software and scripts without having to import the whole of the DRT to do so. It includes the OCDSSchema object. Most of the validation checks for OCDS data are here.
 
-lib-cove-ocds produces results in the form of dictionaries with meaningful keys. cove-ocds is responsible for mapping these keys onto a suitable UI. It's worth noting that cove-ocds is not the only tool that consumes the output of lib-cove-ocds. Different tools can produce the best UI for their particular context, so any UI or display work is done in the tool and not in the underlying library. This also means that the respective UIs can be translated or localised independantly, according to the needs or usage of the tools. Having machine readable output from the library also means that we can take a database of output and easily parse it to create statistics about results or errors, etc.
+lib-cove-ocds produces results in the form of dictionaries with meaningful keys. cove-ocds is responsible for mapping these keys onto a suitable UI. It's worth noting that cove-ocds is not the only tool that consumes the output of lib-cove-ocds. Different tools can produce the best UI for their particular context, so any UI or display work is done in the tool and not in the underlying library. This also means that the respective UIs can be translated or localized independently, according to the needs or usage of the tools. Having machine readable output from the library also means that we can take a database of output and easily parse it to create statistics about results or errors, etc.
 
 External libraries
 ------------------
 
-The OCDS Data Review Tool is just one manifestation of software historically known as 'CoVE' (Convert, Validate, Explore). Instances of CoVE exist for other standards as well as OCDS. We modularise and reuse code where possible, so as a result the DRT has dependencies on external libraries related to CoVE:
+The OCDS Data Review Tool is just one manifestation of software historically known as 'CoVE' (Convert, Validate, Explore). Instances of CoVE exist for other standards as well as OCDS. We modularize and reuse code where possible, so as a result the DRT has dependencies on external libraries related to CoVE:
 
-* lib-cove (`opendataservices/lib-cove <https://github.com/opendataservces/lib-cove>`_): contains functions and helpers that may be useful for data validation and review, regardless of the particular data standard.
+* lib-cove (`opendataservices/lib-cove <https://github.com/opendataservices/lib-cove>`_): contains functions and helpers that may be useful for data validation and review, regardless of the particular data standard.
 * lib-cove-web (`opendataservices/lib-cove-web <https://github.com/opendataservices/lib-cove-web>`_): provides a barebones Django configuration, and baseline CSS, JS and templates that are common for all CoVE instances. It is also a place for common functions relating to presentation or display of data or output. Any templates edited here typically affect all CoVE instances. Sometimes this is useful, but for OCDS-only changes, templates can be overridden in cove-ocds. This and cove-ocds are the only places where frontend output and translatable strings should be.
-* flatten-tool (`opendataservices/lib-cove <https://github.com/opendataservces/flatten-tool>`_): a general purpose library for converting data between JSON and CSV/XLS formats. While not CoVE-specific, it is listed here because it is a specialised tool of which the DRT makes heavy use.
+* flatten-tool (`opendataservices/lib-cove <https://github.com/opendataservices/flatten-tool>`_): a general purpose library for converting data between JSON and CSV/XLS formats. While not CoVE-specific, it is listed here because it is a specialized tool of which the DRT makes heavy use.
 
 Config
 ------
@@ -48,13 +48,13 @@ Some configuration variables are set in ``COVE_CONFIG``, found in ``cove_project
 Path through the code
 ---------------------
 
-1. The input form on the landing page can be found in the ``input`` template (``cove_ocds/templates``). The OCDS DRT overrides the default input template from lib-cove-web so it can be customised compared to other instances of CoVE. This override is set using the ``input_template`` setting in ``COVE_CONFIG`` (see above).
+1. The input form on the landing page can be found in the ``input`` template (``cove_ocds/templates``). The OCDS DRT overrides the default input template from lib-cove-web so it can be customized compared to other instances of CoVE. This override is set using the ``input_template`` setting in ``COVE_CONFIG`` (see above).
 2. Submitting the form calls the `explore_ocds` function (``cove_ocds/views.py``).
   * This checks for basic problems with the input file, and adds metadata, using ``explore_data_context`` from lib-cove-web.
   * It then performs OCDS specific JSON checks, if the input data is JSON.
   * And then schema-specific OCDS checks, depending on the version specified, using ``SchemaOCDS`` and ``common_checks`` from lib-cove-ocds. Functions from lib-cove-ocds also takes care of handling any extension data included in the input. lib-cove-ocds calls on lib-cove to perform schema validation that is not specific to OCDS, using JSON Schema and JSONRef, as well as common things like checking for duplicate identifiers.
   * lib-cove-ocds runs additional checks, which are basic data quality checks outside of the OCDS schema.
-  * The results of the various stages of validation are added to the context so they can be displayed on the frontend. The JSON schema error messages are currently set in lib-cove and OCDS schema specific messages are set in lib-cove-ocds or in this repo (``cove_ocds/lib/exeptions.py``).
+  * The results of the various stages of validation are added to the context so they can be displayed on the frontend. The JSON schema error messages are currently set in lib-cove and OCDS schema specific messages are set in lib-cove-ocds or in this repo (``cove_ocds/lib/exceptions.py``).
   * It uses flattentool to convert the input JSON data into XLSX, or vice versa.
 3. The results of the validation, as well as some basic statistics on the data, are output to the ``explore_record`` and ``explore_release`` html templates in ``cove_ocds/templates``.
 

--- a/docs/how-to-add-a-validation-check.rst
+++ b/docs/how-to-add-a-validation-check.rst
@@ -3,7 +3,7 @@ How to add a validation check
 
 Data validation takes place in the `lib-cove-ocds <https://github.com/open-contracting/lib-cove-ocds>`_ library and are presented in the UI via templates in cove-ocds.
 
-'Common checks' process the various different objects in a release, so the data can be validated against the schema and statistics about different aspects of the data (eg. the number of contracts, the range of dates, or number of unique organisations present) can be presented in the UI. This happens in ``lib/common_checks.py``.
+'Common checks' process the various different objects in a release, so the data can be validated against the schema and statistics about different aspects of the data (eg. the number of contracts, the range of dates, or number of unique organizations present) can be presented in the UI. This happens in ``lib/common_checks.py``.
 
 'Additional checks' are for data validation beyond what is covered by validation against the `OCDS Schema <https://github.com/open-contracting/lib-cove-ocds/blob/master/libcoveocds/schema.py>`_ - that is, the results of these checks may suggest an issue with the data where the issue does not cause data to be invalid against the schema - and are implemented in ``lib/additional_checks.py``. An example of such a check is identifying when fields, objects and arrays exist but are empty or contain only whitespace.
 
@@ -23,7 +23,7 @@ Make new class for your check, subclassing the ``AdditionalCheck`` class in ``li
             pass
 
 
-The items in the ``output`` array should be dicts with a key for ``type`` at a minimum as well as anything else you want to pass through to be displayed in the template. The value of ``type`` is just a string so that in the template you can customise the display of the results of each type of check. Other things in the output might be the JSON path of the value which failed the check, and the value itself.
+The items in the ``output`` array should be dicts with a key for ``type`` at a minimum as well as anything else you want to pass through to be displayed in the template. The value of ``type`` is just a string so that in the template you can customize the display of the results of each type of check. Other things in the output might be the JSON path of the value which failed the check, and the value itself.
 
 Carry out the validation in the ``process`` function of your new class:
 

--- a/docs/how-to-config-frontend.rst
+++ b/docs/how-to-config-frontend.rst
@@ -1,4 +1,4 @@
-How to replace something hardcoded in the frontend with a configureable variable
+How to replace something hardcoded in the frontend with a configurable variable
 ================================================================================
 
 Pick a name for the environment variable you want to configure cove with. In this example we use `MY_ENV_VAR`.

--- a/docs/ocds-show.rst
+++ b/docs/ocds-show.rst
@@ -1,4 +1,4 @@
 OCDS Show
 =========
 
-`OCDS Show <https://github.com/open-contracting/ocds-show>`_ is a JavaScript application for embedding visualisations of OCDS data. The DRT generates data for OCDS Show in ``views.py`` so that it can be embedded in the ``explore_`` templates. Additional functions to help with the data generation for OCDS show are in ``cove_ocds/lib/ocds_show_extra.py``.
+`OCDS Show <https://github.com/open-contracting/ocds-show>`_ is a JavaScript application for embedding visualizations of OCDS data. The DRT generates data for OCDS Show in ``views.py`` so that it can be embedded in the ``explore_`` templates. Additional functions to help with the data generation for OCDS show are in ``cove_ocds/lib/ocds_show_extra.py``.

--- a/docs/template-structure.rst
+++ b/docs/template-structure.rst
@@ -10,9 +10,9 @@ In lib-cove-web you will find:
 * Various error pages.
 * Terms and conditions, usage statistics, analytics.
 
-In cove-ocds (this repo) you will find specialisations of these, either some blocks or entire templates.
+In cove-ocds (this repo) you will find specializations of these, either some blocks or entire templates.
 
-* The base, input, and some of the result table templates customise text and appearance for the OCDS DRT.
+* The base, input, and some of the result table templates customize text and appearance for the OCDS DRT.
 * ``explore_base``, ``explore_record`` and ``explore_release`` modify the base ``explore`` template depending on the data input.
 * Additional template partials which are included in other templates.
 
@@ -30,7 +30,7 @@ Some of the templates include variables for the translation of generic terms so 
   {% trans 'Excel Spreadsheet (.xlsx)' as xlsx %} 
   {% trans 'CSV Spreadsheet (.csv)' as csv %} 
   {% trans 'Excel Spreadsheet (.xlsx) with titles' as xlsx_titles %} 
-  {# Translators: JSON probably does not need a transalation: http://www.json.org/ #}
+  {# Translators: JSON probably does not need a translation: http://www.json.org/ #}
   {% trans 'JSON' as JSON %}
   {% trans 'XML' as XML %}
 


### PR DESCRIPTION
@Bjwebb I noticed a typo in the headline of the new docs you wrote at https://ocds-data-review-tool.readthedocs.io/en/latest/how-to-config-frontend.html so I figured this might be a chance to try out [scspell](https://github.com/myint/scspell) 

PR to correct other typos and to US-ify spelling. 