### PR TITLE
templates validation_table: Icon to indicate that error count is a link

### DIFF
--- a/cove_ocds/templates/cove_ocds/validation_table.html
+++ b/cove_ocds/templates/cove_ocds/validation_table.html
@@ -50,6 +50,7 @@
         <a data-toggle="modal" data-target=".{{"validation-errors-"|concat:forloop.counter}}">
       {% endif %}
         {{values|length}}
+        <span class="glyphicon glyphicon-new-window"></span>
       </a>
     {% else %}
         {{values|length}}


### PR DESCRIPTION
https://github.com/open-contracting/cove-ocds/issues/94

Screenshot:
![Screenshot from 2021-02-12 15-46-42](https://user-images.githubusercontent.com/634/107791613-0f813480-6d4c-11eb-85c6-1433c86ecd5a.png)
